### PR TITLE
Fix team name

### DIFF
--- a/api/github.go
+++ b/api/github.go
@@ -65,7 +65,7 @@ func (c *GithubClient) GetTeam(name string, id int) (team *github.Team, err erro
 
 	} else {
 		for _, localTeam := range teams {
-			if *localTeam.ID == id || *localTeam.Name == name {
+			if *localTeam.ID == id || *localTeam.Slug == name {
 				team = localTeam
 				// team found
 				return


### PR DESCRIPTION
## what
* Use `slug` instead of `name` to select a GitHub team

## why
* Slugs are more appropriate for external references as they are normalized 
* Related discussion [here](https://github.com/concourse/atc/pull/137)