### PR TITLE
Do not build binaries for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --config ./dev.goreleaser.yml --clean --snapshot
+          args: release --config ./.goreleaser.yml --clean --snapshot
 
   release:
     if: github.event_name == 'push'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,9 +36,30 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 
-#release:
-# If you want to manually examine the release before it is live, uncomment this line:
-# draft: true
+signs:
+  - artifacts: checksum
+    args:
+      # since we are using this in a GitHub action we need to pass the batch flag to indicate its not interactive.
+      - "--batch"
+      - "--local-user"
+      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+      - "--output"
+      - "${signature}"
+      - "--detach-sign"
+      - "${artifact}"
+
+## Copied from https://github.com/cloudposse/.github/blob/main/.github/goreleaser.yml
+## Required to correct working go auto release workflow
+## ----- DO NOT CHANGE ----- ##
+release:
+  draft: true
+  replace_existing_draft: true
+  replace_existing_artifacts: true
+  mode: keep-existing
+  make_latest: false
+  name_template: 'v{{.Tag}}'
+  target_commitish: "{{ .Branch }}"
+## ----- DO NOT CHANGE ----- ##
 
 changelog:
   skip: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,18 +36,6 @@ checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 
-signs:
-  - artifacts: checksum
-    args:
-      # since we are using this in a GitHub action we need to pass the batch flag to indicate its not interactive.
-      - "--batch"
-      - "--local-user"
-      - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
-      - "--output"
-      - "${signature}"
-      - "--detach-sign"
-      - "${artifact}"
-
 ## Copied from https://github.com/cloudposse/.github/blob/main/.github/goreleaser.yml
 ## Required to correct working go auto release workflow
 ## ----- DO NOT CHANGE ----- ##


### PR DESCRIPTION
## what
* Use custom `.goreleaser.yaml`

## why
* `github-authorized-keys` should not build for windows that we do for org global config 